### PR TITLE
Inclui `language` na escrita dos nomes no certificado

### DIFF
--- a/src/draw.py
+++ b/src/draw.py
@@ -174,4 +174,5 @@ class Draw:
             "fill": self.get_setting("fill", "#000000"),
             "font": self.font,
             "spacing": self.get_setting("spacing", 10),
+            "language": "pt-BR"
         }


### PR DESCRIPTION
Para que os nomes com acento sejam escritos da forma correta, o argumento `language` precisa ser incluído na criação dos certificados.

`language` depende da lib `libraqm`: https://pillow.readthedocs.io/en/stable/installation.html?highlight=libraqm